### PR TITLE
Move definition of LIBCELLML_MATHML_DTD_LOCATION 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,12 @@ configure_file(
   ${LIBCELLML_CONFIG_H}
 )
 
+set(MATHML_CONFIG_H "${CMAKE_CURRENT_BINARY_DIR}/mathml_config.h")
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/configure/mathml_config.h.in"
+  ${MATHML_CONFIG_H}
+)
+
 set(SOURCE_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/component.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/componententity.cpp
@@ -75,10 +81,11 @@ set(API_HEADER_FILES
 )
 
 set(HEADER_FILES
-  ${LIBCELLML_CONFIG_H}
   ${CMAKE_CURRENT_SOURCE_DIR}/xmlattribute.h
   ${CMAKE_CURRENT_SOURCE_DIR}/xmldoc.h
   ${CMAKE_CURRENT_SOURCE_DIR}/xmlnode.h
+  ${LIBCELLML_CONFIG_H}
+  ${MATHML_CONFIG_H}
 )
 
 # Only does anything if configuration target is Visual Studio.

--- a/src/configure/mathml_config.h.in
+++ b/src/configure/mathml_config.h.in
@@ -14,20 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef LIBCELLML_LIBCELLML_CONFIG_H
-#define LIBCELLML_LIBCELLML_CONFIG_H
+#ifndef LIBCELLML_MATHML_CONFIG_H
+#define LIBCELLML_MATHML_CONFIG_H
 
 #include <string>
 
 namespace libcellml {
 
-#define LIBCELLML_VERSION_MAJOR @libCellML_VERSION_MAJOR@
-#define LIBCELLML_VERSION_MINOR @libCellML_VERSION_MINOR@
-#define LIBCELLML_VERSION_PATCH @libCellML_VERSION_PATCH@
-
-static unsigned int LIBCELLML_LIBRARY_VERSION=@LIBCELLML_LIBRARY_VERSION@;
-static const std::string LIBCELLML_LIBRARY_VERSION_STRING="@LIBCELLML_LIBRARY_VERSION_STRING@";
+static const std::string LIBCELLML_MATHML_DTD_LOCATION="@LIBCELLML_MATHML_DTD_LOCATION@";
 
 }
 
-#endif /* LIBCELLML_LIBCELLML_CONFIG_H */
+#endif /* LIBCELLML_MATHML_CONFIG_H */

--- a/src/xmldoc.cpp
+++ b/src/xmldoc.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "libcellml_config.h"
+#include "mathml_config.h"
 #include "xmlnode.h"
 
 namespace libcellml {


### PR DESCRIPTION
Putting this definition into it's own header file.
